### PR TITLE
feat: Implement pull-to-refresh functionality across multiple screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1420,10 +1420,13 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
         backgroundColor: Colors.white,
         body: Stack(
           children: [
-            SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
+            RefreshIndicator(
+              onRefresh: () => fetchTransactionSummary(updateCarousel: true),
+              child: SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Container(
@@ -1476,7 +1479,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                   ],
                 ),
               ),
-            ),
+            ),),
             if (_isLoading)
               Container(
                 color: Colors.black12,

--- a/lib/screens/NotificationScreen.dart
+++ b/lib/screens/NotificationScreen.dart
@@ -126,6 +126,11 @@ class _NotificationScreenState extends State<NotificationScreen>
     }
   }
 
+  Future<void> _refreshData() async {
+    final type = _tabController.index == 0 ? 'RiskHold' : 'Settlement';
+    await _fetchData(type);
+  }
+
   String _formatDate(dynamic timestamp) {
     if (timestamp == null) return '';
 
@@ -298,32 +303,41 @@ class _NotificationScreenState extends State<NotificationScreen>
     }
 
     if (items.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+      return RefreshIndicator(
+        onRefresh: _refreshData,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
           children: [
-            Icon(
-              Icons.notifications_none_outlined,
-              size: 64,
-              color: Colors.grey.shade300,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              "No notifications found",
-              style: TextStyle(
-                fontFamily: 'Montserrat',
-                color: Colors.grey.shade600,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              "You're all caught up!",
-              style: TextStyle(
-                fontFamily: 'Montserrat',
-                color: Colors.grey.shade500,
-                fontSize: 14,
+            SizedBox(height: MediaQuery.of(context).size.height * 0.2),
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.notifications_none_outlined,
+                    size: 64,
+                    color: Colors.grey.shade300,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "No notifications found",
+                    style: TextStyle(
+                      fontFamily: 'Montserrat',
+                      color: Colors.grey.shade600,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    "You're all caught up!",
+                    style: TextStyle(
+                      fontFamily: 'Montserrat',
+                      color: Colors.grey.shade500,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
               ),
             ),
           ],
@@ -331,10 +345,13 @@ class _NotificationScreenState extends State<NotificationScreen>
       );
     }
 
-    return ListView.builder(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      itemCount: items.length,
-      itemBuilder: (_, index) => _buildNotificationItem(items[index]),
+    return RefreshIndicator(
+      onRefresh: _refreshData,
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: items.length,
+        itemBuilder: (_, index) => _buildNotificationItem(items[index]),
+      ),
     );
   }
 

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -540,38 +540,34 @@ class _ProfileScreenState extends State<ProfileScreen> with SingleTickerProvider
       child: Scaffold(
         backgroundColor: backgroundColor,
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16), // Reduced vertical padding
-            child: SingleChildScrollView(
-              physics: const BouncingScrollPhysics(),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Voice Out Toggle Section
-                  _buildVoiceOutSection(primaryColor, textColor),
-                  const SizedBox(height: 8), // Reduced from 10
-                  _buildLanguageDropdown(primaryColor, borderColor, textColor),
-                  const SizedBox(height: 16), // Reduced from 20
-                  // Divider after QR Sticker line
-                  _buildDivider(),
-                  const SizedBox(height: 16),
+          child: RefreshIndicator(
+            onRefresh: _loadProfileData,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              children: [
+                // Voice Out Toggle Section
+                _buildVoiceOutSection(primaryColor, textColor),
+                const SizedBox(height: 8), // Reduced from 10
+                _buildLanguageDropdown(primaryColor, borderColor, textColor),
+                const SizedBox(height: 16), // Reduced from 20
+                // Divider after QR Sticker line
+                _buildDivider(),
+                const SizedBox(height: 16),
 
+                // Merchant Details - Without Card
+                _buildMerchantDetails(textColor),
 
-                  // Merchant Details - Without Card
-                  _buildMerchantDetails(textColor),
+                const SizedBox(height: 36),
 
-                  const SizedBox(height: 36),
+                // Divider before logout
+                _buildDivider(),
+                const SizedBox(height: 16),
 
-                  // Divider before logout
-                  _buildDivider(),
-                  const SizedBox(height: 16),
-
-                  // Logout Section
-                  _buildLogoutSection(textColor),
-                  const SizedBox(height: 16),
-
-                ],
-              ),
+                // Logout Section
+                _buildLogoutSection(textColor),
+                const SizedBox(height: 16),
+              ],
             ),
           ),
         ),

--- a/lib/screens/report_screen.dart
+++ b/lib/screens/report_screen.dart
@@ -798,32 +798,42 @@ class _TransactionReportPageState extends State<TransactionReportPage>
     }
 
     if (items.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+      return RefreshIndicator(
+        onRefresh: _refreshData,
+        color: customPurple,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
           children: [
-            Icon(
-              Icons.insert_drive_file_outlined,
-              size: 64,
-              color: Colors.grey.shade300,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              "No reports available",
-              style: TextStyle(
-                fontFamily: 'Montserrat',
-                color: Colors.grey.shade600,
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              "Pull down to refresh",
-              style: TextStyle(
-                fontFamily: 'Montserrat',
-                color: Colors.grey.shade500,
-                fontSize: 14,
+            SizedBox(height: MediaQuery.of(context).size.height * 0.2),
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.insert_drive_file_outlined,
+                    size: 64,
+                    color: Colors.grey.shade300,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "No reports available",
+                    style: TextStyle(
+                      fontFamily: 'Montserrat',
+                      color: Colors.grey.shade600,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    "Pull down to refresh",
+                    style: TextStyle(
+                      fontFamily: 'Montserrat',
+                      color: Colors.grey.shade500,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
               ),
             ),
           ],

--- a/lib/screens/support_screen.dart
+++ b/lib/screens/support_screen.dart
@@ -372,7 +372,16 @@ class _SupportScreenState extends State<SupportScreen> {
                 ),
               )
                   : _tickets.isEmpty
-                  ? _buildEmptyState()
+                  ? LayoutBuilder(builder: (context, constraints) {
+                      return SingleChildScrollView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        child: ConstrainedBox(
+                          constraints:
+                              BoxConstraints(minHeight: constraints.maxHeight),
+                          child: _buildEmptyState(),
+                        ),
+                      );
+                    })
                   : ListView.builder(
                 controller: _scrollController,
                 itemCount: _tickets.length + 1,

--- a/lib/screens/transactions_screen.dart
+++ b/lib/screens/transactions_screen.dart
@@ -2256,32 +2256,41 @@ class _TransactionsScreenState extends State<TransactionsScreen> with SingleTick
     }
 
     if (transactions.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+      return RefreshIndicator(
+        onRefresh: () => fetchTransactions(txnStatus, txnType),
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
           children: [
-            Icon(
-              Icons.receipt_long_outlined,
-              size: 48,
-              color: Colors.grey[400],
-            ),
-            SizedBox(height: 16),
-            Text(
-              'No transactions found',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey[600],
-                fontWeight: FontWeight.w500,
+            SizedBox(height: MediaQuery.of(context).size.height * 0.2),
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.receipt_long_outlined,
+                    size: 48,
+                    color: Colors.grey[400],
+                  ),
+                  SizedBox(height: 16),
+                  Text(
+                    'No transactions found',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey[600],
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Text(
+                    'Try changing your filters or select a different terminal',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey[500],
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
               ),
-            ),
-            SizedBox(height: 8),
-            Text(
-              'Try changing your filters or select a different terminal',
-              style: TextStyle(
-                fontSize: 14,
-                color: Colors.grey[500],
-              ),
-              textAlign: TextAlign.center,
             ),
           ],
         ),
@@ -2318,10 +2327,12 @@ class _TransactionsScreenState extends State<TransactionsScreen> with SingleTick
       return dateB.compareTo(dateA); // Sort descending (newest first)
     });
 
-    return ListView.builder(
-      controller: _scrollController, // Keep existing scroll controller
-      itemCount: dateKeys.length + (isLoadingMore ? 1 : 0), // +1 for loading indicator
-      itemBuilder: (context, index) {
+    return RefreshIndicator(
+      onRefresh: () => fetchTransactions(txnStatus, txnType),
+      child: ListView.builder(
+        controller: _scrollController, // Keep existing scroll controller
+        itemCount: dateKeys.length + (isLoadingMore ? 1 : 0), // +1 for loading indicator
+        itemBuilder: (context, index) {
         if (isLoadingMore && index == dateKeys.length) {
           return Center(
             child: Padding(
@@ -2367,7 +2378,7 @@ class _TransactionsScreenState extends State<TransactionsScreen> with SingleTick
 
 
       },
-    );
+    ),);
   }
 
   DateTime _parseDateTime(String dateStr) {
@@ -2440,32 +2451,41 @@ class _TransactionsScreenState extends State<TransactionsScreen> with SingleTick
     }
 
     if (transactions.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+      return RefreshIndicator(
+        onRefresh: fetchStaticQRTransactions,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
           children: [
-            Icon(
-              Icons.qr_code_outlined,
-              size: 48,
-              color: Colors.grey[400],
-            ),
-            SizedBox(height: 16),
-            Text(
-              'No transactions found',
-              style: TextStyle(
-                fontSize: 16,
-                color: Colors.grey[600],
-                fontWeight: FontWeight.w500,
+            SizedBox(height: MediaQuery.of(context).size.height * 0.2),
+            Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.qr_code_outlined,
+                    size: 48,
+                    color: Colors.grey[400],
+                  ),
+                  SizedBox(height: 16),
+                  Text(
+                    'No transactions found',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey[600],
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Text(
+                    'Try changing your filters or select a different VPA',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey[500],
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
               ),
-            ),
-            SizedBox(height: 8),
-            Text(
-              'Try changing your filters or select a different VPA',
-              style: TextStyle(
-                fontSize: 14,
-                color: Colors.grey[500],
-              ),
-              textAlign: TextAlign.center,
             ),
           ],
         ),
@@ -2520,10 +2540,12 @@ class _TransactionsScreenState extends State<TransactionsScreen> with SingleTick
       return dateB.compareTo(dateA); // Sort other dates descending (newest first)
     });
 
-    return ListView.builder(
-      controller: _scrollController, // Keep existing scroll controller
-      itemCount: dateKeys.length + (isLoadingMore ? 1 : 0),
-      itemBuilder: (context, index) {
+    return RefreshIndicator(
+      onRefresh: fetchStaticQRTransactions,
+      child: ListView.builder(
+        controller: _scrollController, // Keep existing scroll controller
+        itemCount: dateKeys.length + (isLoadingMore ? 1 : 0),
+        itemBuilder: (context, index) {
         if (isLoadingMore && index == dateKeys.length) {
           return Center(
             child: Padding(
@@ -2569,7 +2591,7 @@ class _TransactionsScreenState extends State<TransactionsScreen> with SingleTick
 
 
       },
-    );
+    ),);
   }
 
   void _resetFilters() {


### PR DESCRIPTION
This commit introduces pull-to-refresh functionality to enhance the user experience by allowing easy data reloading on key screens. The `RefreshIndicator` widget has been implemented on the following screens:

- **HomeScreen**: The main dashboard, including the transaction summary and recent transactions, can now be refreshed.
- **TransactionsScreen**: Both the 'POS' and 'Static QR' transaction lists can be refreshed. The empty state views have also been made refreshable.
- **ReportScreen**: The 'Transaction' and 'Settlement' report lists are now refreshable, including when the lists are empty.
- **RiskHoldScreen**: The existing `RefreshIndicator` was confirmed to be working correctly.
- **NotificationScreen**: Both the 'Risk Hold' and 'Settlement' notification tabs are now refreshable, including their empty states.
- **SupportScreen**: The support ticket list is now refreshable, with the empty state view updated to be scrollable to support the gesture.
- **ProfileScreen**: The user's profile and bank details can now be reloaded with a pull-to-refresh gesture.

To ensure a consistent experience, all screens with potentially empty lists have been updated to use a scrollable layout for their empty-state views, enabling the refresh gesture at all times.