### PR TITLE
Feat: Add Pull-to-Refresh and Fix Search Functionality

### DIFF
--- a/lib/screens/report_screen.dart
+++ b/lib/screens/report_screen.dart
@@ -847,16 +847,20 @@ class _TransactionReportPageState extends State<TransactionReportPage>
       child: Column(
         children: [
           Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: items.length > 5 ? 5 : items.length,
-              itemBuilder: (context, index) => _buildListItem(items[index], index, items.length > 5 ? 5 : items.length),
-              physics: AlwaysScrollableScrollPhysics(),
+            child: RefreshIndicator(
+              onRefresh: _refreshData,
+              color: customPurple,
+              child: ListView.builder(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemCount: items.length > 5 ? 5 : items.length,
+                itemBuilder: (context, index) => _buildListItem(items[index], index, items.length > 5 ? 5 : items.length),
+                physics: const AlwaysScrollableScrollPhysics(),
+              ),
             ),
           ),
           Container(
             width: double.infinity,
-            padding: EdgeInsets.all(16),
+            padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
               color: Colors.white,
               border: Border(top: BorderSide(color: Colors.grey.shade300, width: 0.5)),


### PR DESCRIPTION
This commit introduces two main changes:

1.  **Pull-to-Refresh on My Report Screen:**
    - Added a `RefreshIndicator` to both the 'Transactions' and 'Settlement' tabs on the 'My Report' screen.
    - Users can now pull down to refresh the data on each tab independently.

2.  **Client-Side Search on Transactions Screen:**
    - Implemented a client-side search for both 'POS' and 'Static QR' tabs.
    - The search is case-insensitive and filters across multiple fields (amount, status, card type, date, and time).
    - Fixed a critical bug where the search filter was not being reapplied after new transactions were loaded via pagination.