### PR TITLE
feat: Add TID and VPA functionality to dropdowns

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,8 @@ dependencies:
   firebase_messaging: any
   firebase_core: any
   flutter_local_notifications: any
+  qr_code_scanner: ^1.0.1
+  fluttertoast: ^8.2.4
 
 dev_dependencies:
   flutter_launcher_icons: ^0.14.4


### PR DESCRIPTION
This commit introduces new functionality to the Home Screen dropdowns for Terminal IDs (TID) and Static QRs (VPA).

- Adds an "+ Add TID" button to the TID dropdown footer. This opens a dialog for the user to enter a new TID, which is then added via an API call.
- Adds an "+ Add VPA" button to the VPA dropdown footer. This opens a dialog that allows the user to scan a QR code to add a new VPA, which is then added via an API call.
- The dropdown lists are refreshed upon successful addition of a new TID or VPA.
- Includes the `qr_code_scanner` and `fluttertoast` dependencies to support these new features.
- Modifies the `CustomDropdownFieldWithBarrier` widget to accept a `footerBuilder`, allowing for the inclusion of custom action buttons in the dropdown menu.